### PR TITLE
feat: add OpenRouter provider support

### DIFF
--- a/src/libriscribe/main.py
+++ b/src/libriscribe/main.py
@@ -1,4 +1,5 @@
 # src/libriscribe/main.py
+import sys
 import typer
 from libriscribe.agents.project_manager import ProjectManagerAgent
 from typing import List, Dict, Any
@@ -41,6 +42,8 @@ def select_llm(project_knowledge_base: ProjectKnowledgeBase):
     available_llms = []
     settings = Settings()
 
+    if settings.openrouter_api_key:
+        available_llms.append("openrouter")
     if settings.openai_api_key:
         available_llms.append("openai")
     if settings.claude_api_key:

--- a/src/libriscribe/settings.py
+++ b/src/libriscribe/settings.py
@@ -8,6 +8,9 @@ class Settings(BaseSettings):
     claude_api_key: str = ""
     deepseek_api_key: str = ""
     mistral_api_key: str = ""
+    openrouter_api_key: str = ""
+    openrouter_base_url: str = "https://openrouter.ai/api/v1"
+    openrouter_model: str = "anthropic/claude-3-haiku"
     projects_dir: str = str(Path(__file__).parent.parent.parent / "projects")
     default_llm: str = "openai" # Set a default
 

--- a/src/libriscribe/utils/llm_client.py
+++ b/src/libriscribe/utils/llm_client.py
@@ -30,7 +30,12 @@ class LLMClient:
 
     def _get_client(self):
         """Initializes the appropriate client based on the provider."""
-        if self.llm_provider == "openai":
+        if self.llm_provider == "openrouter":
+            return OpenAI(
+                api_key=self.settings.openrouter_api_key,
+                base_url=self.settings.openrouter_base_url
+            )
+        elif self.llm_provider == "openai":
             if not self.settings.openai_api_key:
                 raise ValueError("OpenAI API key is not set.")
             return OpenAI(api_key=self.settings.openai_api_key)
@@ -56,7 +61,9 @@ class LLMClient:
 
     def _get_default_model(self):
         """Gets the default model name for the selected provider."""
-        if self.llm_provider == "openai":
+        if self.llm_provider == "openrouter":
+            return self.settings.openrouter_model
+        elif self.llm_provider == "openai":
             return "gpt-4o-mini"
         elif self.llm_provider == "claude":
             return "claude-3-opus-20240229" # Or another appropriate Claude 3 model


### PR DESCRIPTION
## Summary
This PR adds OpenRouter as an LLM provider option, enabling access to 50+ models through a single API.

## Changes
- Add OpenRouter configuration to settings (3 lines)
- Implement OpenRouter in LLM client using OpenAI-compatible API (9 lines)
- Add OpenRouter to provider selection menu (2 lines)
- Fix missing sys import in main.py (1 line)

## Testing
- Tested with OpenRouter API key
- Successfully generated content using anthropic/claude-3-haiku model
- All existing providers continue to work

## Implementation Notes
- Minimal changes following existing patterns
- OpenRouter uses OpenAI-compatible API, reducing complexity
- No breaking changes to existing functionality