### PR TITLE
fix: escape JSON braces in f-string template

### DIFF
--- a/src/libriscribe/agents/concept_generator.py
+++ b/src/libriscribe/agents/concept_generator.py
@@ -8,13 +8,19 @@ from pathlib import Path
 from libriscribe.utils.llm_client import LLMClient
 from libriscribe.utils import prompts_context as prompts
 from libriscribe.agents.agent_base import Agent
-from libriscribe.utils.file_utils import extract_json_from_markdown, read_json_file, write_json_file
+from libriscribe.utils.file_utils import (
+    extract_json_from_markdown,
+    read_json_file,
+    write_json_file,
+)
 from libriscribe.knowledge_base import ProjectKnowledgeBase
-#No need to import track
-from rich.console import Console #NEW IMPORT
 
-console = Console() # Create a console instance.
+# No need to import track
+from rich.console import Console  # NEW IMPORT
+
+console = Console()  # Create a console instance.
 logger = logging.getLogger(__name__)
+
 
 class ConceptGeneratorAgent(Agent):
     """Generates book concepts."""
@@ -22,7 +28,11 @@ class ConceptGeneratorAgent(Agent):
     def __init__(self, llm_client: LLMClient):
         super().__init__("ConceptGeneratorAgent", llm_client)
 
-    def execute(self, project_knowledge_base: ProjectKnowledgeBase, output_path: Optional[str] = None) -> None:
+    def execute(
+        self,
+        project_knowledge_base: ProjectKnowledgeBase,
+        output_path: Optional[str] = None,
+    ) -> None:
         """Generates a book concept, with critique and refinement."""
         try:
             # --- Step 1: Initial Concept Generation (Simplified) ---
@@ -38,11 +48,11 @@ class ConceptGeneratorAgent(Agent):
                     - "description": A short description (around 100-150 words).
 
                     ```json
-                    {
+                    {{{{
                         "title": "...",
                         "logline": "...",
                         "description": "..."
-                    }
+                    }}}}
                     ```"""
             else:
                 initial_prompt = f"""Generate a book concept for a {project_knowledge_base.genre} {project_knowledge_base.category} ({project_knowledge_base.book_length}).
@@ -56,15 +66,17 @@ class ConceptGeneratorAgent(Agent):
                 - "description": A description (around 200 words).
 
                 ```json
-                {{
+                {{{{{{{{
                     "title": "...",
                     "logline": "...",
                     "description": "..."
-                }}
+                }}}}}}}}
                 ```"""
 
             console.print(f"🧠 [cyan]Generating initial concept...[/cyan]")
-            initial_concept_md = self.llm_client.generate_content_with_json_repair(initial_prompt)
+            initial_concept_md = self.llm_client.generate_content_with_json_repair(
+                initial_prompt
+            )
 
             if not initial_concept_md:
                 logger.error("Initial concept generation failed.")
@@ -79,7 +91,7 @@ class ConceptGeneratorAgent(Agent):
             critique_prompt = f"""Critique the following book concept:
 
             ```json
-            {json.dumps(initial_concept_json)}
+            {{{{json.dumps(initial_concept_json)}}}}
             ```
             The book should be written in {project_knowledge_base.language}.
            
@@ -94,14 +106,13 @@ class ConceptGeneratorAgent(Agent):
                 logger.error("Critique generation failed.")
                 return None
 
-
             # --- Step 3: Refine the Concept ---
             refine_prompt = f"""Refine the book concept based on the critique.  Address the weaknesses and improve the concept.
             The book should be written in {project_knowledge_base.language}.
 
             Original Concept:
             ```json
-            {json.dumps(initial_concept_json)}
+            {{{{json.dumps(initial_concept_json)}}}}
             ```
 
             Critique:
@@ -109,15 +120,17 @@ class ConceptGeneratorAgent(Agent):
 
             Return the REFINED concept as a JSON object within a Markdown code block:
              ```json
-            {{
+            {{{{{{{{
                 "title": "...",
                 "logline": "...",
                 "description": "..."
-            }}
+            }}}}}}}}
             ```
             """
             console.print(f"✨ [cyan]Refining concept...[/cyan]")
-            refined_concept_md = self.llm_client.generate_content_with_json_repair(refine_prompt)
+            refined_concept_md = self.llm_client.generate_content_with_json_repair(
+                refine_prompt
+            )
             if not refined_concept_md:
                 logger.error("Refined concept generation failed.")
                 return None
@@ -128,14 +141,16 @@ class ConceptGeneratorAgent(Agent):
                 return None
 
             # --- Step 4: Update ProjectData (using refined concept) ---
-            if 'title' in refined_concept_json:
-                project_knowledge_base.title = refined_concept_json['title']
-            if 'logline' in refined_concept_json:
-                project_knowledge_base.logline = refined_concept_json['logline']
-            if 'description' in refined_concept_json:
-                project_knowledge_base.description = refined_concept_json['description']
+            if "title" in refined_concept_json:
+                project_knowledge_base.title = refined_concept_json["title"]
+            if "logline" in refined_concept_json:
+                project_knowledge_base.logline = refined_concept_json["logline"]
+            if "description" in refined_concept_json:
+                project_knowledge_base.description = refined_concept_json["description"]
 
-            logger.info(f"Concept generated (refined): Title: {project_knowledge_base.title}, Logline: {project_knowledge_base.logline}")
+            logger.info(
+                f"Concept generated (refined): Title: {project_knowledge_base.title}, Logline: {project_knowledge_base.logline}"
+            )
 
         except Exception as e:
             self.logger.exception(f"Error generating concept: {e}")


### PR DESCRIPTION
## Bug Fix: JSON Template F-String Error

### Problem
The concept generator was crashing with `ValueError: Invalid format specifier` when using JSON templates inside f-strings. Literal braces `{}` in f-strings are interpreted as format specifiers, causing crashes in the advanced path workflow.

### Root Cause
```python
# ❌ This causes ValueError in f-strings:
f"""```json
{
    "title": "...",
    "logline": "..."
}
```"""